### PR TITLE
fix(lang): Broken syntax in messages_es

### DIFF
--- a/Pro/src/main/resources/lang/messages_es.yml
+++ b/Pro/src/main/resources/lang/messages_es.yml
@@ -110,7 +110,7 @@ Command:
     Desc: 'Mostrar todos los trabajos.'
   Objectives:
     Usage: '<trabajo>'
-    Desc:' Ver los objetivos de trabajo.'
+    Desc: 'Ver los objetivos de trabajo.'
   Drop:
     Usage: '<moneda> (<cantidad> o <min>:<max>) <mundo> <x> <y> <z>'
     Desc: 'Crear y soltar la moneda.'


### PR DESCRIPTION
Since the YML syntax is broken the plugin throws an exception and regenerates all the locales in english.